### PR TITLE
Reglene for UGYLDIG_KODEVERK_FOR_HOVEDDIAGNOSE slo til hvis hoveddiag…

### DIFF
--- a/src/main/kotlin/no/nav/syfo/papirsykemelding/rules/ValideringRuleChain.kt
+++ b/src/main/kotlin/no/nav/syfo/papirsykemelding/rules/ValideringRuleChain.kt
@@ -68,12 +68,16 @@ enum class ValideringRuleChain(
                     sykemelding.medisinskVurdering.hovedDiagnose == null
         }),
 
-    @Description("Hvis kodeverk ikke er angitt eller korrekt for hoveddiagnose, avvises meldingen.")
+    @Description("Hvis feil kodeverk er angitt hoveddiagnose avvises meldingen.")
     UGYLDIG_KODEVERK_FOR_HOVEDDIAGNOSE(
         1540,
         Status.MANUAL_PROCESSING,
         "Den må ha riktig kode for hoveddiagnose.",
         "Kodeverk for hoveddiagnose er feil eller mangler.", { (sykemelding, _) ->
+
+            if (sykemelding.medisinskVurdering.hovedDiagnose == null) {
+                false
+            } else {
             sykemelding.medisinskVurdering.hovedDiagnose?.system !in arrayOf(
                 Diagnosekoder.ICPC2_CODE,
                 Diagnosekoder.ICD10_CODE
@@ -85,7 +89,7 @@ enum class ValideringRuleChain(
                             Diagnosekoder.icd10.containsKey(diagnose.kode)
                         }
                     } != true
-        }),
+        }}),
 
     // Revurder regel når IT ikkje lenger skal brukes
     // Her mener jeg fremdeles at vi skal nulle ut bidiagnosen dersom den er feil - ikke avvise sykmeldingen!!

--- a/src/main/kotlin/no/nav/syfo/papirsykemelding/rules/ValideringRuleChain.kt
+++ b/src/main/kotlin/no/nav/syfo/papirsykemelding/rules/ValideringRuleChain.kt
@@ -73,7 +73,7 @@ enum class ValideringRuleChain(
         1540,
         Status.MANUAL_PROCESSING,
         "Den må ha riktig kode for hoveddiagnose.",
-        "Kodeverk for hoveddiagnose er feil eller mangler.", { (sykemelding, _) ->
+        "Kodeverk for hoveddiagnose er feil.", { (sykemelding, _) ->
 
             if (sykemelding.medisinskVurdering.hovedDiagnose == null) {
                 false

--- a/src/test/kotlin/no/nav/syfo/papirsykemelding/rules/PeriodLogicRuleChainSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/papirsykemelding/rules/PeriodLogicRuleChainSpek.kt
@@ -157,7 +157,7 @@ object PeriodLogicRuleChainSpek : Spek({
                 perioder = listOf(
                     Periode(
                         fom = LocalDate.now().minusYears(3).minusDays(14),
-                        tom =  LocalDate.now().minusYears(3),
+                        tom = LocalDate.now().minusYears(3),
                         aktivitetIkkeMulig = null,
                         avventendeInnspillTilArbeidsgiver = null,
                         behandlingsdager = 1,

--- a/src/test/kotlin/no/nav/syfo/papirsykemelding/rules/ValidationRuleChainSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/papirsykemelding/rules/ValidationRuleChainSpek.kt
@@ -429,6 +429,40 @@ object ValidationRuleChainSpek : Spek({
             ValideringRuleChain.UGYLDIG_KODEVERK_FOR_HOVEDDIAGNOSE(ruleData(sykemelding)) shouldEqual true
         }
 
+        it("Should check rule UGYLDIG_KODEVERK_FOR_HOVEDDIAGNOSE, null hovedDiagnose should not trigger") {
+            val sykemelding = Sykmelding("1",
+                "1",
+                "2",
+                MedisinskVurdering(
+                    hovedDiagnose = null,
+                    biDiagnoser = emptyList(),
+                    svangerskap = false,
+                    yrkesskadeDato = null,
+                    annenFraversArsak = null,
+                    yrkesskade = false
+                ),
+                false,
+                generateArbeidsgiver(),
+                generatePerioder(),
+                generatePrognose(),
+                emptyMap(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                generateKontaktMedPasient(),
+                behandletTidspunkt,
+                generateBehandler(),
+                AvsenderSystem("test", "1"),
+                null,
+                signaturDato,
+                null
+            )
+
+            ValideringRuleChain.UGYLDIG_KODEVERK_FOR_HOVEDDIAGNOSE(ruleData(sykemelding)) shouldEqual false
+        }
+
         it("Should check rule UGYLDIG_KODEVERK_FOR_BIDIAGNOSE, wrong kodeverk for biDiagnoser") {
             val sykemelding = Sykmelding("1",
                 "1",


### PR DESCRIPTION
Reglene for UGYLDIG_KODEVERK_FOR_HOVEDDIAGNOSE slo til hvis hoveddiagnose = null, men dette er feil

Hoveddiagnose kan være null så lenge annenFraversArsak != null, og dette sjekkes i HOVEDDIAGNOSE_ELLER_FRAVAERSGRUNN_MANGLER

TODO: Sjekk om dette er feil i syfosmregler også