### PR TITLE
ser bort fra tilbakedateringer som gjelder korona eller ICD10

### DIFF
--- a/src/test/kotlin/no/nav/syfo/TestData.kt
+++ b/src/test/kotlin/no/nav/syfo/TestData.kt
@@ -59,7 +59,7 @@ fun generateSykemelding(
     tidspunkt: LocalDateTime = behandletTidspunkt,
     signaturDateTime: LocalDateTime = signaturDato,
     kontaktMedPasient: KontaktMedPasient = generateKontaktMedPasient(),
-    diagnose: Diagnose = Diagnosekoder.icd10.values.stream().findFirst().get().toDiagnose()
+    diagnose: Diagnose = Diagnosekoder.icpc2.values.stream().findFirst().get().toDiagnose()
 ): Sykmelding {
     return Sykmelding(
         "1",
@@ -140,7 +140,7 @@ fun generateArbeidsgiver(): Arbeidsgiver {
     return Arbeidsgiver(HarArbeidsgiver.EN_ARBEIDSGIVER, null, null, null)
 }
 
-fun generateMedisinskVurdering(diagnose: Diagnose = Diagnosekoder.icd10.values.stream().findFirst().get().toDiagnose()): MedisinskVurdering {
+fun generateMedisinskVurdering(diagnose: Diagnose = Diagnosekoder.icpc2.values.stream().findFirst().get().toDiagnose()): MedisinskVurdering {
     return MedisinskVurdering(
         hovedDiagnose = diagnose,
         biDiagnoser = emptyList(),

--- a/src/test/kotlin/no/nav/syfo/papirsykemelding/rules/SyketilfelleRuleChainSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/papirsykemelding/rules/SyketilfelleRuleChainSpek.kt
@@ -4,8 +4,10 @@ import io.kotest.core.spec.style.FunSpec
 import no.nav.syfo.generateKontaktMedPasient
 import no.nav.syfo.generatePeriode
 import no.nav.syfo.generateSykemelding
+import no.nav.syfo.model.Diagnose
 import no.nav.syfo.model.KontaktMedPasient
 import no.nav.syfo.papirsykemelding.model.RuleMetadata
+import no.nav.syfo.sm.Diagnosekoder
 import org.amshove.kluent.shouldBeEqualTo
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -14,67 +16,6 @@ import java.time.LocalTime
 class SyketilfelleRuleChainSpek : FunSpec({
 
     context("Testing validation rules and checking the rule outcomes") {
-
-        test("Should check rule TILBAKEDATERT_INNTIL_8_DAGER_UTEN_KONTAKTDATO_OG_BEGRUNNELSE, should trigger rule") {
-            val healthInformation = generateSykemelding(
-                perioder = listOf(
-                    generatePeriode(
-                        fom = LocalDate.of(2019, 1, 3),
-                        tom = LocalDate.of(2019, 1, 8)
-                    )
-                ),
-                kontaktMedPasient = KontaktMedPasient(null, null)
-            )
-
-            val ruleMetadataAndForstegangsSykemelding =
-                RuleMetadataAndForstegangsSykemelding(
-                    ruleMetadata = RuleMetadata(
-                        receivedDate = LocalDateTime.now(),
-                        signatureDate = LocalDateTime.of(LocalDate.of(2019, 1, 8), LocalTime.NOON),
-                        behandletTidspunkt = LocalDateTime.of(LocalDate.of(2019, 1, 8), LocalTime.NOON),
-                        patientPersonNumber = "1232345244",
-                        rulesetVersion = "2",
-                        legekontorOrgnr = "12313",
-                        tssid = "1355435",
-                        pasientFodselsdato = LocalDate.of(1980, 1, 1)
-                    ),
-                    erNyttSyketilfelle = true
-                )
-
-            SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding)
-                .getRuleByName("TILBAKEDATERT_INNTIL_8_DAGER_UTEN_KONTAKTDATO_OG_BEGRUNNELSE")
-                .executeRule().result shouldBeEqualTo true
-        }
-
-        test("Should check rule TILBAKEDATERT_INNTIL_8_DAGER_UTEN_KONTAKTDATO, should NOT trigger rule") {
-            val healthInformation = generateSykemelding(
-                perioder = listOf(
-                    generatePeriode(
-                        fom = LocalDate.of(2019, 1, 7),
-                        tom = LocalDate.of(2019, 1, 8)
-                    )
-                )
-            )
-
-            val ruleMetadataAndForstegangsSykemelding =
-                RuleMetadataAndForstegangsSykemelding(
-                    ruleMetadata = RuleMetadata(
-                        receivedDate = LocalDateTime.now(),
-                        signatureDate = LocalDateTime.of(LocalDate.of(2019, 1, 8), LocalTime.NOON),
-                        behandletTidspunkt = LocalDateTime.of(LocalDate.of(2019, 1, 8), LocalTime.NOON),
-                        patientPersonNumber = "1232345244",
-                        rulesetVersion = "2",
-                        legekontorOrgnr = "12313",
-                        tssid = "1355435",
-                        pasientFodselsdato = LocalDate.of(1980, 1, 1)
-                    ),
-                    erNyttSyketilfelle = false
-                )
-
-            SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding).getRuleByName("TILBAKEDATERT_INNTIL_8_DAGER_UTEN_KONTAKTDATO_OG_BEGRUNNELSE")
-                .executeRule()
-                .result shouldBeEqualTo false
-        }
 
         test("Should check rule TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING, should trigger rule") {
             val healthInformation = generateSykemelding(
@@ -132,6 +73,230 @@ class SyketilfelleRuleChainSpek : FunSpec({
                 )
 
             SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding).getRuleByName("TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING")
+                .executeRule().result shouldBeEqualTo false
+        }
+
+        test("TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING trigges ikke hvis diagnosekode er ICD10") {
+            val healthInformation = generateSykemelding(
+                perioder = listOf(
+                    generatePeriode(
+                        fom = LocalDate.of(2019, 1, 10),
+                        tom = LocalDate.of(2019, 1, 20)
+                    )
+                ),
+                kontaktMedPasient = KontaktMedPasient(null, null),
+                diagnose = Diagnose(Diagnosekoder.ICD10_CODE, "A000", "")
+            )
+
+            val ruleMetadataAndForstegangsSykemelding =
+                RuleMetadataAndForstegangsSykemelding(
+                    ruleMetadata = RuleMetadata(
+                        receivedDate = LocalDateTime.now(),
+                        signatureDate = LocalDateTime.of(LocalDate.of(2019, 1, 19), LocalTime.NOON),
+                        behandletTidspunkt = LocalDateTime.of(LocalDate.of(2019, 1, 19), LocalTime.NOON),
+                        patientPersonNumber = "1232345244",
+                        rulesetVersion = "2",
+                        legekontorOrgnr = "12313",
+                        tssid = "1355435",
+                        pasientFodselsdato = LocalDate.of(1980, 1, 1)
+                    ),
+                    erNyttSyketilfelle = true
+                )
+
+            SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding).getRuleByName("TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING")
+                .executeRule().result shouldBeEqualTo false
+        }
+
+        test("Should check rule TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING_MED_BEGRUNNELSE, should trigger rule") {
+            val healthInformation = generateSykemelding(
+                perioder = listOf(
+                    generatePeriode(
+                        fom = LocalDate.now().minusDays(9),
+                        tom = LocalDate.now()
+                    )
+                ),
+                kontaktMedPasient = generateKontaktMedPasient(
+                    begrunnelseIkkeKontakt = "Noe tull skjedde, med sykmeldingen"
+                )
+            )
+
+            val ruleMetadataAndForstegangsSykemelding =
+                RuleMetadataAndForstegangsSykemelding(
+                    ruleMetadata = RuleMetadata(
+                        receivedDate = LocalDateTime.now(),
+                        signatureDate = LocalDateTime.now(),
+                        behandletTidspunkt = LocalDateTime.now(),
+                        patientPersonNumber = "1232345244",
+                        rulesetVersion = "2",
+                        legekontorOrgnr = "12313",
+                        tssid = "1355435",
+                        pasientFodselsdato = LocalDate.of(1980, 1, 1)
+                    ),
+                    erNyttSyketilfelle = true
+                )
+
+            SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding)
+                .getRuleByName("TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING_MED_BEGRUNNELSE")
+                .executeRule().result shouldBeEqualTo true
+        }
+
+        test("Should check rule TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING_MED_BEGRUNNELSE, should NOT trigger rule") {
+            val healthInformation = generateSykemelding(
+                perioder = listOf(
+                    generatePeriode(
+                        fom = LocalDate.now().minusDays(7),
+                        tom = LocalDate.now()
+                    )
+                ),
+                kontaktMedPasient = generateKontaktMedPasient(
+                    begrunnelseIkkeKontakt = "Noe tull skjedde, med sykmeldingen"
+                )
+            )
+
+            val ruleMetadataAndForstegangsSykemelding =
+                RuleMetadataAndForstegangsSykemelding(
+                    ruleMetadata = RuleMetadata(
+                        receivedDate = LocalDateTime.now(),
+                        signatureDate = LocalDateTime.now(),
+                        behandletTidspunkt = LocalDateTime.now(),
+                        patientPersonNumber = "1232345244",
+                        rulesetVersion = "2",
+                        legekontorOrgnr = "12313",
+                        tssid = "1355435",
+                        pasientFodselsdato = LocalDate.of(1980, 1, 1)
+                    ),
+                    erNyttSyketilfelle = true
+                )
+
+            SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding)
+                .getRuleByName("TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING_MED_BEGRUNNELSE")
+                .executeRule().result shouldBeEqualTo false
+        }
+
+        test("TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING_MED_BEGRUNNELSE trigges ikke hvis diagnosekode er ICD10") {
+            val healthInformation = generateSykemelding(
+                perioder = listOf(
+                    generatePeriode(
+                        fom = LocalDate.now().minusDays(9),
+                        tom = LocalDate.now()
+                    )
+                ),
+                kontaktMedPasient = generateKontaktMedPasient(
+                    begrunnelseIkkeKontakt = "Noe tull skjedde, med sykmeldingen"
+                ),
+                diagnose = Diagnose(Diagnosekoder.ICD10_CODE, "A000", "")
+            )
+
+            val ruleMetadataAndForstegangsSykemelding =
+                RuleMetadataAndForstegangsSykemelding(
+                    ruleMetadata = RuleMetadata(
+                        receivedDate = LocalDateTime.now(),
+                        signatureDate = LocalDateTime.now(),
+                        behandletTidspunkt = LocalDateTime.now(),
+                        patientPersonNumber = "1232345244",
+                        rulesetVersion = "2",
+                        legekontorOrgnr = "12313",
+                        tssid = "1355435",
+                        pasientFodselsdato = LocalDate.of(1980, 1, 1)
+                    ),
+                    erNyttSyketilfelle = true
+                )
+
+            SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding)
+                .getRuleByName("TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING_MED_BEGRUNNELSE")
+                .executeRule().result shouldBeEqualTo false
+        }
+
+        test("Should check rule TILBAKEDATERT_INNTIL_8_DAGER_UTEN_KONTAKTDATO_OG_BEGRUNNELSE, should trigger rule") {
+            val healthInformation = generateSykemelding(
+                perioder = listOf(
+                    generatePeriode(
+                        fom = LocalDate.of(2019, 1, 3),
+                        tom = LocalDate.of(2019, 1, 8)
+                    )
+                ),
+                kontaktMedPasient = KontaktMedPasient(null, null)
+            )
+
+            val ruleMetadataAndForstegangsSykemelding =
+                RuleMetadataAndForstegangsSykemelding(
+                    ruleMetadata = RuleMetadata(
+                        receivedDate = LocalDateTime.now(),
+                        signatureDate = LocalDateTime.of(LocalDate.of(2019, 1, 8), LocalTime.NOON),
+                        behandletTidspunkt = LocalDateTime.of(LocalDate.of(2019, 1, 8), LocalTime.NOON),
+                        patientPersonNumber = "1232345244",
+                        rulesetVersion = "2",
+                        legekontorOrgnr = "12313",
+                        tssid = "1355435",
+                        pasientFodselsdato = LocalDate.of(1980, 1, 1)
+                    ),
+                    erNyttSyketilfelle = true
+                )
+
+            SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding)
+                .getRuleByName("TILBAKEDATERT_INNTIL_8_DAGER_UTEN_KONTAKTDATO_OG_BEGRUNNELSE")
+                .executeRule().result shouldBeEqualTo true
+        }
+
+        test("Should check rule TILBAKEDATERT_INNTIL_8_DAGER_UTEN_KONTAKTDATO_OG_BEGRUNNELSE, should NOT trigger rule") {
+            val healthInformation = generateSykemelding(
+                perioder = listOf(
+                    generatePeriode(
+                        fom = LocalDate.of(2019, 1, 7),
+                        tom = LocalDate.of(2019, 1, 8)
+                    )
+                )
+            )
+
+            val ruleMetadataAndForstegangsSykemelding =
+                RuleMetadataAndForstegangsSykemelding(
+                    ruleMetadata = RuleMetadata(
+                        receivedDate = LocalDateTime.now(),
+                        signatureDate = LocalDateTime.of(LocalDate.of(2019, 1, 8), LocalTime.NOON),
+                        behandletTidspunkt = LocalDateTime.of(LocalDate.of(2019, 1, 8), LocalTime.NOON),
+                        patientPersonNumber = "1232345244",
+                        rulesetVersion = "2",
+                        legekontorOrgnr = "12313",
+                        tssid = "1355435",
+                        pasientFodselsdato = LocalDate.of(1980, 1, 1)
+                    ),
+                    erNyttSyketilfelle = false
+                )
+
+            SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding).getRuleByName("TILBAKEDATERT_INNTIL_8_DAGER_UTEN_KONTAKTDATO_OG_BEGRUNNELSE")
+                .executeRule()
+                .result shouldBeEqualTo false
+        }
+
+        test("TILBAKEDATERT_INNTIL_8_DAGER_UTEN_KONTAKTDATO_OG_BEGRUNNELSE trigges ikke hvis diagnosekode er ICD10") {
+            val healthInformation = generateSykemelding(
+                perioder = listOf(
+                    generatePeriode(
+                        fom = LocalDate.of(2019, 1, 3),
+                        tom = LocalDate.of(2019, 1, 8)
+                    )
+                ),
+                kontaktMedPasient = KontaktMedPasient(null, null),
+                diagnose = Diagnose(Diagnosekoder.ICD10_CODE, "A000", "")
+            )
+
+            val ruleMetadataAndForstegangsSykemelding =
+                RuleMetadataAndForstegangsSykemelding(
+                    ruleMetadata = RuleMetadata(
+                        receivedDate = LocalDateTime.now(),
+                        signatureDate = LocalDateTime.of(LocalDate.of(2019, 1, 8), LocalTime.NOON),
+                        behandletTidspunkt = LocalDateTime.of(LocalDate.of(2019, 1, 8), LocalTime.NOON),
+                        patientPersonNumber = "1232345244",
+                        rulesetVersion = "2",
+                        legekontorOrgnr = "12313",
+                        tssid = "1355435",
+                        pasientFodselsdato = LocalDate.of(1980, 1, 1)
+                    ),
+                    erNyttSyketilfelle = true
+                )
+
+            SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding)
+                .getRuleByName("TILBAKEDATERT_INNTIL_8_DAGER_UTEN_KONTAKTDATO_OG_BEGRUNNELSE")
                 .executeRule().result shouldBeEqualTo false
         }
 
@@ -227,69 +392,33 @@ class SyketilfelleRuleChainSpek : FunSpec({
                 .executeRule().result shouldBeEqualTo false
         }
 
-        test("Should check rule TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING_MED_BEGRUNNELSE, should trigger rule") {
+        test("TILBAKEDATERT_FORLENGELSE_OVER_1_MND trigges ikke hvis diagnosekode er ICD10") {
             val healthInformation = generateSykemelding(
                 perioder = listOf(
                     generatePeriode(
-                        fom = LocalDate.now().minusDays(9),
-                        tom = LocalDate.now()
+                        fom = LocalDate.of(2019, 10, 10),
+                        tom = LocalDate.of(2019, 10, 20)
                     )
                 ),
-                kontaktMedPasient = generateKontaktMedPasient(
-                    begrunnelseIkkeKontakt = "Noe tull skjedde, med sykmeldingen"
-                )
+                diagnose = Diagnose(Diagnosekoder.ICD10_CODE, "A000", "")
             )
 
             val ruleMetadataAndForstegangsSykemelding =
                 RuleMetadataAndForstegangsSykemelding(
-                    ruleMetadata = RuleMetadata(
+                    RuleMetadata(
                         receivedDate = LocalDateTime.now(),
                         signatureDate = LocalDateTime.now(),
-                        behandletTidspunkt = LocalDateTime.now(),
+                        behandletTidspunkt = LocalDateTime.of(LocalDate.of(2019, 11, 11), LocalTime.NOON),
                         patientPersonNumber = "1232345244",
                         rulesetVersion = "2",
                         legekontorOrgnr = "12313",
                         tssid = "1355435",
                         pasientFodselsdato = LocalDate.of(1980, 1, 1)
                     ),
-                    erNyttSyketilfelle = true
+                    erNyttSyketilfelle = false
                 )
 
-            SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding)
-                .getRuleByName("TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING_MED_BEGRUNNELSE")
-                .executeRule().result shouldBeEqualTo true
-        }
-
-        test("Should check rule TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING_MED_BEGRUNNELSE, should NOT trigger rule") {
-            val healthInformation = generateSykemelding(
-                perioder = listOf(
-                    generatePeriode(
-                        fom = LocalDate.now().minusDays(7),
-                        tom = LocalDate.now()
-                    )
-                ),
-                kontaktMedPasient = generateKontaktMedPasient(
-                    begrunnelseIkkeKontakt = "Noe tull skjedde, med sykmeldingen"
-                )
-            )
-
-            val ruleMetadataAndForstegangsSykemelding =
-                RuleMetadataAndForstegangsSykemelding(
-                    ruleMetadata = RuleMetadata(
-                        receivedDate = LocalDateTime.now(),
-                        signatureDate = LocalDateTime.now(),
-                        behandletTidspunkt = LocalDateTime.now(),
-                        patientPersonNumber = "1232345244",
-                        rulesetVersion = "2",
-                        legekontorOrgnr = "12313",
-                        tssid = "1355435",
-                        pasientFodselsdato = LocalDate.of(1980, 1, 1)
-                    ),
-                    erNyttSyketilfelle = true
-                )
-
-            SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding)
-                .getRuleByName("TILBAKEDATERT_MER_ENN_8_DAGER_FORSTE_SYKMELDING_MED_BEGRUNNELSE")
+            SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding).getRuleByName("TILBAKEDATERT_FORLENGELSE_OVER_1_MND")
                 .executeRule().result shouldBeEqualTo false
         }
 
@@ -367,6 +496,40 @@ class SyketilfelleRuleChainSpek : FunSpec({
                         tom = LocalDate.now()
                     )
                 )
+            )
+
+            val ruleMetadataAndForstegangsSykemelding =
+                RuleMetadataAndForstegangsSykemelding(
+                    ruleMetadata = RuleMetadata(
+                        receivedDate = LocalDateTime.now(),
+                        signatureDate = LocalDateTime.now().plusDays(30),
+                        behandletTidspunkt = LocalDateTime.now().plusDays(30),
+                        patientPersonNumber = "1232345244",
+                        rulesetVersion = "2",
+                        legekontorOrgnr = "12313",
+                        tssid = "1355435",
+                        pasientFodselsdato = LocalDate.of(1980, 1, 1)
+                    ),
+                    erNyttSyketilfelle = false
+                )
+
+            SyketilfelleRuleChain(healthInformation, ruleMetadataAndForstegangsSykemelding)
+                .getRuleByName("TILBAKEDATERT_MED_BEGRUNNELSE_FORLENGELSE")
+                .executeRule().result shouldBeEqualTo false
+        }
+
+        test("TILBAKEDATERT_MED_BEGRUNNELSE_FORLENGELSE trigges ikke hvis diagnosekode er ICD10") {
+            val healthInformation = generateSykemelding(
+                perioder = listOf(
+                    generatePeriode(
+                        fom = LocalDate.now(),
+                        tom = LocalDate.now()
+                    )
+                ),
+                kontaktMedPasient = generateKontaktMedPasient(
+                    begrunnelseIkkeKontakt = "Noe tull skjedde, med sykmeldingen"
+                ),
+                diagnose = Diagnose(Diagnosekoder.ICD10_CODE, "A000", "")
             )
 
             val ruleMetadataAndForstegangsSykemelding =


### PR DESCRIPTION
For å bedre lesbarheten har jeg også endret litt på rekkefølgen på testene slik at de kommer i samme rekkefølge som reglene. 